### PR TITLE
Add support for wrapping a win32 window as a IUIItemContainer

### DIFF
--- a/src/TestStack.White/Mappings/ControlDictionary.cs
+++ b/src/TestStack.White/Mappings/ControlDictionary.cs
@@ -69,6 +69,7 @@ namespace TestStack.White.Mappings
             items.AddWPFPrimary(typeof(Image), ControlType.Image);
             items.AddSilverlightPrimary(typeof(Image), ControlType.Image);
             items.AddWin32Primary(typeof(Image), ControlType.Image);
+            items.AddWin32Primary(typeof(Win32Window), ControlType.Window);
 
             items.AddSilverlightPrimary(typeof(SilverlightChildWindow), ControlType.Window);
 

--- a/src/TestStack.White/UIItems/WindowItems/Win32Window.cs
+++ b/src/TestStack.White/UIItems/WindowItems/Win32Window.cs
@@ -5,6 +5,7 @@ using System.Windows.Automation;
 using TestStack.White.AutomationElementSearch;
 using TestStack.White.Factory;
 using TestStack.White.Sessions;
+using TestStack.White.UIItems.Actions;
 using TestStack.White.UIItems.Finders;
 using TestStack.White.UIItems.MenuItems;
 
@@ -21,6 +22,11 @@ namespace TestStack.White.UIItems.WindowItems
             : base(automationElement, option, windowSession)
         {
             this.windowFactory = windowFactory;
+        }
+
+        public Win32Window(AutomationElement automationElement, IActionListener actionListener) : base(automationElement, actionListener, InitializeOption.NoCache, new NullWindowSession())
+        {
+            this.windowFactory = WindowFactory.Desktop;
         }
 
         public override PopUpMenu Popup


### PR DESCRIPTION
The changes required for the Vasterbotten case.